### PR TITLE
Fix `update` behavior

### DIFF
--- a/microcosm_fastapi/database/store.py
+++ b/microcosm_fastapi/database/store.py
@@ -120,7 +120,7 @@ class StoreAsync:
             async with self.with_transaction(session):
                 async with self.flushing(session):
                     instance = await self.retrieve(identifier)
-                    await self.merge(instance, new_instance)
+                    await self.merge(instance, new_instance, session)
                     instance.updated_at = instance.new_timestamp()
         return instance
 
@@ -135,7 +135,7 @@ class StoreAsync:
                 async with self.flushing(session):
                     instance = await self.retrieve(identifier)
                     before = Version(instance)
-                    await self.merge(instance, new_instance)
+                    await self.merge(instance, new_instance, session)
                     instance.updated_at = instance.new_timestamp()
                     after = Version(instance)
         return instance, before - after
@@ -201,9 +201,8 @@ class StoreAsync:
         async with self.session_maker() as session:
             return session.expunge(instance)
 
-    async def merge(self, instance, new_instance):
-        async with self.session_maker() as session:
-            await session.merge(new_instance)
+    async def merge(self, instance, new_instance, session):
+        await session.merge(new_instance)
 
     async def get_all(self, query):
         async with self.session_maker() as session:


### PR DESCRIPTION
Our previous logic was creating two separate sessions when trying to
update an object. Because we wrap our object modifications with a
separate `with_transaction` the wrong session was picking up our object
changes. As a result, at merge time the behavior was a no-op.

Update the API contract of the merge function to pass in the session.
This will allow client callers to easily override the merge behavior
(much like in the original microcosm-postgres logic) while respecting
the session that the base store is opening within `update` and
`update_with_diff`.