### PR TITLE
Fix merge into session

### DIFF
--- a/microcosm_fastapi/database/store.py
+++ b/microcosm_fastapi/database/store.py
@@ -143,10 +143,10 @@ class StoreAsync:
         """
         async with self.with_maybe_transactional_flushing_session(session) as session:
             instance = await self.retrieve(identifier)
-            result = await self.merge(instance, new_instance, session)
+            await self.merge(instance, new_instance, session)
             instance.updated_at = instance.new_timestamp()
 
-        return result
+        return instance
 
     @postgres_metric_timing(action="update_with_diff")
     async def update_with_diff(self, identifier, new_instance, session: Optional[AsyncSession] = None):
@@ -157,11 +157,11 @@ class StoreAsync:
         async with self.with_maybe_transactional_flushing_session(session) as session:
             instance = await self.retrieve(identifier, session=session)
             before = Version(instance)
-            result = await self.merge(instance, new_instance, session)
+            await self.merge(instance, new_instance, session)
             instance.updated_at = instance.new_timestamp()
             after = Version(instance)
 
-        return result, before - after
+        return instance, before - after
 
     async def replace(self, identifier, new_instance, session: Optional[AsyncSession] = None):
         """
@@ -226,7 +226,7 @@ class StoreAsync:
             return session.expunge(instance)
 
     async def merge(self, instance, new_instance, session: AsyncSession):
-        return await session.merge(new_instance)
+        await session.merge(new_instance)
 
     async def get_all(self, query, session: Optional[AsyncSession] = None):
         async with self.with_maybe_session(session) as session:


### PR DESCRIPTION
sqlalchemy merge doesn't return values; instead rely on the instance variable itself to be returned to client callers.