### PR TITLE
Removing fastapi version pin

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.5
+current_version = 0.1.6
 commit = False
 tag = False
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,16 +40,17 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.nox/
+coverage/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
+*,cover
+cover
+.hypothesis
+coverage/
+**/tests/test-results/**
 
 # Translations
 *.mo

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     keywords="microcosm",
     install_requires=[
         "microcosm>=3.0.0",
-        "fastapi==0.63.0", # pinning due to issues with issues with higher versions
+        # "fastapi==0.63.0", # pinning due to issues with issues with higher versions
+        "fastapi",
         "uvicorn",
         "aiofiles",
         "SQLAlchemy>=1.4.0",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     keywords="microcosm",
     install_requires=[
         "microcosm>=3.0.0",
-        # "fastapi==0.63.0", # pinning due to issues with issues with higher versions
         "fastapi",
         "uvicorn",
         "aiofiles",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-fastapi"
-version = "0.1.5"
+version = "0.1.6"
 
 
 setup(


### PR DESCRIPTION
We're safe to unpin the fastapi version. No issues found with higher versions.