### PR TITLE
Adding a pool pre ping to sqlalchemy connections

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = False
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -202,3 +202,23 @@ pip install pytest pytest-cov pytest-asyncio
 cd test-project
 pytest test_project
 ```
+
+## Bumping Versions
+
+When you're ready to merge your PR, you'll need to bump the version of package.
+There are two files that you need to update with the new version you're bumping to:
+```sh
+setup.py
+.bumpversion.cfg
+```
+
+As soon as you've bumped your version and pushes the bumps into the repo then merge your PR.
+
+Once the PR has been merged, checkout the latest from master and push the respective tags
+```shell
+git checkout master
+git pull
+git tag X.X.X 
+git push --tags
+```
+

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ setup.py
 .bumpversion.cfg
 ```
 
-As soon as you've bumped your version and pushes the bumps into the repo then merge your PR.
+As soon as you've bumped your version and pushed your changes, then merge your PR.
 
-Once the PR has been merged, checkout the latest from master and push the respective tags
+Once the PR has been merged, checkout the latest from master then tag and push:
 ```shell
 git checkout master
 git pull

--- a/microcosm_fastapi/database/postgres.py
+++ b/microcosm_fastapi/database/postgres.py
@@ -40,6 +40,8 @@ def choose_args(metadata, config):
         max_overflow=config.max_overflow,
         pool_size=config.pool_size,
         pool_timeout=config.pool_timeout,
+        # TODO - move to microcosm @defaults + deal with postgres / postgres_async bindings
+        pool_pre_ping=True,
     )
 
 

--- a/microcosm_fastapi/database/postgres.py
+++ b/microcosm_fastapi/database/postgres.py
@@ -40,13 +40,13 @@ def choose_args(metadata, config):
         max_overflow=config.max_overflow,
         pool_size=config.pool_size,
         pool_timeout=config.pool_timeout,
-        # TODO - move to microcosm @defaults + deal with postgres / postgres_async bindings
+        # GLOB-60776 - move to microcosm @defaults + deal with postgres / postgres_async bindings
         pool_pre_ping=True,
     )
 
 
 def make_engine(metadata, config):
-    # TODO - move to microcosm @defaults + deal with postgres / postgres_async bindings
+    # GLOB-60776 - move to microcosm @defaults + deal with postgres / postgres_async bindings
     # Required for async engine - so override user preferences
     config.postgres.driver = "postgresql+asyncpg"
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-fastapi"
-version = "0.1.4"
+version = "0.1.5"
 
 
 setup(


### PR DESCRIPTION
Ticket: https://globality.atlassian.net/browse/GLOB-60739

We were seeing issues to do with picking up invalid connections and trying to connect to the db:
```
message:(sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.ConnectionDoesNotExistError'>: connection was closed in the middle of operation
```

The pool pre ping makes sure we have valid connections before running our application database queries by issuing a pre-statement such as "SELECT 1". See sqlalchemy docs here -> https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic