### PR TITLE
Force require asyncio as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "fastapi",
         "uvicorn",
         "aiofiles",
-        "SQLAlchemy>=1.4.0",
+        "SQLAlchemy>=1.4.0[asyncio]",
         "httpx",
         "h11<0.13", # @pierce 01-24-2022 pin because of httpx conflict
         "click",


### PR DESCRIPTION
Greenlet isn't detected on M1 macs, which affects the requirements generation of downstream services. See [here](https://github.com/sqlalchemy/sqlalchemy/issues/7714) for more details. Here we force require it as a dependency to go along with our async postgres.