### PR TITLE
Use fastapi default response

### DIFF
--- a/microcosm_fastapi/audit.py
+++ b/microcosm_fastapi/audit.py
@@ -63,7 +63,7 @@ def should_skip_logging(request: Request) -> bool:
     Should we skip logging for this handler?
 
     """
-    return strtobool(request.headers.get("x-request-nolog", "false"))
+    return bool(strtobool(request.headers.get("x-request-nolog", "false")))
 
 
 class RequestInfo:

--- a/microcosm_fastapi/database/encryption/store.py
+++ b/microcosm_fastapi/database/encryption/store.py
@@ -49,7 +49,7 @@ class EncryptableStoreAsync(StoreAsync):
         # If updating a non encrypted field - skip
         if new_instance.plaintext is None and new_instance.encrypted_relationship is None:
             result = super().update(identifier, new_instance)
-            self.expunge(result, session=session)
+            await self.expunge(result, session=session)
             return result
 
         # Verify that the new instance is encrypted if it should be
@@ -70,7 +70,7 @@ class EncryptableStoreAsync(StoreAsync):
             await self.encrypted_store.delete(old_encrypted_identifier, session=session)
 
         # Update the return result, super().update() won't do it.
-        self.expunge(result, session=session)
+        await self.expunge(result, session=session)
         result.plaintext = expected_new_plaintext
         return result
 

--- a/microcosm_fastapi/factories/fastapi.py
+++ b/microcosm_fastapi/factories/fastapi.py
@@ -84,10 +84,19 @@ class FastAPIWrapper(FastAPI):
         return kwargs
 
     def inject_default_response(self, kwargs):
+        default_response = {
+            "description": "Successful Response",
+            "content": {
+                "application/json": {
+                    "schema": {}
+                }
+            }
+        }
+
         if kwargs.get("responses", None):
-            kwargs["responses"]["default"] = {"model": ErrorSchema}
+            kwargs["responses"][200] = default_response
         else:
-            kwargs["responses"] = {"default": {"model": ErrorSchema}}
+            kwargs["responses"] = {200: default_response}
 
         return kwargs
 

--- a/microcosm_fastapi/factories/fastapi.py
+++ b/microcosm_fastapi/factories/fastapi.py
@@ -2,8 +2,6 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from microcosm.api import defaults, typed
 
-from microcosm_fastapi.errors import ErrorSchema
-
 
 class FastAPIWrapper(FastAPI):
     """

--- a/microcosm_fastapi/tests/conftest.py
+++ b/microcosm_fastapi/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from microcosm.object_graph import create_object_graph
 
@@ -17,7 +18,7 @@ def graph():
     return create_object_graph(name="example", testing=True)
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def client(graph):
     async with AsyncClient(app=graph.app, base_url="http://localhost") as client:
         yield client

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "fastapi",
         "uvicorn",
         "aiofiles",
-        "SQLAlchemy>=1.4.0[asyncio]",
+        "SQLAlchemy[asyncio]>=1.4.0",
         "httpx",
         "h11<0.13", # @pierce 01-24-2022 pin because of httpx conflict
         "click",


### PR DESCRIPTION
The latest version of microcosm-fastapi & fastapi sees a crash on service initialization if we use the docs factory to provide automatic documentation.

Specifically, it crashes with this error:

```
  File "/usr/local/lib/python3.10/dist-packages/fastapi/utils.py", line 24, in is_body_allowed_for_status_code
    current_status_code = int(status_code)
ValueError: invalid literal for int() with base 10: 'default'
```

Traced it down to the following default response decorator, which includes this defaults key:
https://github.com/globality-corp/microcosm-fastapi/blob/master/microcosm_fastapi/factories/fastapi.py#L88

Fastapi broke this logic by introducing an additional assert that ensures response codes are numeric. The "default" string is being treated as the response code here, which cases the error.
https://github.com/tiangolo/fastapi/commit/c43120258fa89bc20d6f8ee671b6ead9ab223fc7

Here we change the default response code to be 200, along with the payload that fastapi includes in their schemas by default.