### PR TITLE
Add python CI context for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
   node-executor:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:14.16.1
+      - image: cimg/node:14.19.0
         environment:
           EXTRA_INDEX_URL: "InjectedDuringRuntime"
           AWS_ECR_DOMAIN: "InjectedDuringRuntime"
@@ -27,7 +27,7 @@ executors:
   globality-build-executor:
     working_directory: ~/repo
     docker:
-      - image: ${AWS_ECR_DOMAIN}/globality-build:2021.21.1
+      - image: ${AWS_ECR_DOMAIN}/globality-build:2022.31.0
         aws_auth:
           aws_access_key_id: ${AWS_ACCESS_KEY_ID}
           aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -39,7 +39,7 @@ executors:
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2021.21.1
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2022.31.0
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -54,7 +54,7 @@ defaults: &defaults
 deploy_defaults: &deploy_defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2021.21.1
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2022.31.0
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -112,6 +112,7 @@ jobs:
               --build-arg JFROG_AUTH=$JFROG_AUTH .
 
             docker push $AWS_ECR_DOMAIN/python-library:$CIRCLE_SHA1
+
 
   test:
     <<: *defaults
@@ -175,7 +176,6 @@ jobs:
 
 
 
-
   typehinting:
     <<: *defaults
 
@@ -205,22 +205,23 @@ jobs:
             docker run -it --volumes-from service_tests ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1} typehinting
 
 
+
   deploy_jfrog_rc:
     <<: *defaults
     steps:
       - attach_workspace:
           at: ~/repo
       - run:
-          name: Deploy
+          name: Deploy  # If package publishing enabled, always push RCs to JFrog
           command: |
             echo "[distutils]" > ~/.pypirc
             echo "index-servers =" >> ~/.pypirc
-            echo "    jfrog " >> ~/.pypirc
+            echo "    jfrog" >> ~/.pypirc
             echo >> ~/.pypirc
             echo "[jfrog]" >> ~/.pypirc
-            echo "repository = https://globality.jfrog.io/globality/api/pypi/pypi" >> ~/.pypirc
-            echo "username   = $JFROG_USERNAME" >> ~/.pypirc
-            echo "password   = $JFROG_PASSWORD" >> ~/.pypirc
+            echo "repository:https://globality.jfrog.io/globality/api/pypi/pypi" >> ~/.pypirc
+            echo "username:$JFROG_USERNAME" >> ~/.pypirc
+            echo "password:$JFROG_PASSWORD" >> ~/.pypirc
             echo >> ~/.pypirc
             echo >> ~/.pypirc
             version=0.${CIRCLE_BUILD_NUM}.dev${CIRCLE_BUILD_NUM}
@@ -250,6 +251,7 @@ jobs:
             python setup.py register -r pypi
             python setup.py sdist
             twine upload --repository pypi dist/microcosm-fastapi-${version}.tar.gz
+
 
 
 workflows:
@@ -309,6 +311,7 @@ workflows:
       - publish_library:
           context: 
           - Globality-Common
+          - Python-Context
           requires:
             - test
             - lint

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -7,5 +7,5 @@
     }
   },
   "type": "python-library",
-  "version": "2021.21.1"
+  "version": "2022.31.0"
 }


### PR DESCRIPTION
We've recently added a separate CI role for publishing artifacts to pypi. Regenerate our circle pipeline with the latest globality-build to restore the environment variables we need for a successful deploy.